### PR TITLE
chore(downgrade): Downgrade Hibernate Validator

### DIFF
--- a/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>8.0.0.Final</version>
+            <version>7.0.5.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

### :pencil: Description
- Downgrade the version of Hibernate Validator to 7.0.5.Final

### :link: Related Issues
N/A
