### PR TITLE
refactor(project): Use the new package names

### DIFF
--- a/openapi/pom.xml
+++ b/openapi/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.expediagroup.openworld.sdk</groupId>
     <artifactId>travel-sdk-generators-openapi</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <name>EG Open World SDK Tooling :: Generators :: OpenAPI</name>
     <description>SDK Generator for building SDKs based on OpenAPI specs</description>
     <url>https://github.com/ExpediaGroup/openworld-sdk-java-generators/tree/main/openapi</url>

--- a/openapi/src/main/resources/templates/openworld-sdk/api.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/api.mustache
@@ -10,16 +10,16 @@ import {{packageName}}.models.exception.PropertyConstraintViolation
 import {{packageName}}.validation.PropertyConstraintsValidator.validateConstraints
 
 {{#isRapid}}
-import com.expediagroup.sdk.core.client.openapi.RapidOpenApiStub
+import com.expediagroup.openworld.sdk.core.client.openapi.RapidOpenApiStub
 {{/isRapid}}
 {{^isRapid}}
-import com.expediagroup.sdk.core.client.openapi.OpenApiStub
+import com.expediagroup.openworld.sdk.core.client.openapi.OpenApiStub
 {{/isRapid}}
-import com.expediagroup.sdk.core.config.provider.FileConfigurationProvider
-import com.expediagroup.sdk.core.configuration.{{#isRapid}}Rapid{{/isRapid}}ClientConfiguration
-import com.expediagroup.sdk.core.model.exception.OpenWorldException
-import com.expediagroup.sdk.core.model.exception.client.*
-import com.expediagroup.sdk.core.model.exception.service.*
+import com.expediagroup.openworld.sdk.core.config.provider.FileConfigurationProvider
+import com.expediagroup.openworld.sdk.core.configuration.{{#isRapid}}Rapid{{/isRapid}}ClientConfiguration
+import com.expediagroup.openworld.sdk.core.model.exception.OpenWorldException
+import com.expediagroup.openworld.sdk.core.model.exception.client.*
+import com.expediagroup.openworld.sdk.core.model.exception.service.*
 
 
 import jakarta.validation.ConstraintViolation

--- a/openapi/src/main/resources/templates/openworld-sdk/api.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/api.mustache
@@ -10,17 +10,21 @@ import {{packageName}}.models.exception.PropertyConstraintViolation
 import {{packageName}}.validation.PropertyConstraintsValidator.validateConstraints
 
 {{#isRapid}}
-import com.expediagroup.openworld.sdk.core.client.openapi.RapidOpenApiStub
+import com.expediagroup.sdk.core.client.openapi.RapidOpenApiStub
+import com.expediagroup.sdk.core.configuration.RapidClientConfiguration
+import com.expediagroup.sdk.core.config.provider.FileConfigurationProvider
+import com.expediagroup.sdk.core.model.exception.OpenWorldException
+import com.expediagroup.sdk.core.model.exception.client.*
+import com.expediagroup.sdk.core.model.exception.service.*
 {{/isRapid}}
 {{^isRapid}}
 import com.expediagroup.openworld.sdk.core.client.openapi.OpenApiStub
-{{/isRapid}}
+import com.expediagroup.openworld.sdk.core.configuration.ClientConfiguration
 import com.expediagroup.openworld.sdk.core.config.provider.FileConfigurationProvider
-import com.expediagroup.openworld.sdk.core.configuration.{{#isRapid}}Rapid{{/isRapid}}ClientConfiguration
 import com.expediagroup.openworld.sdk.core.model.exception.OpenWorldException
 import com.expediagroup.openworld.sdk.core.model.exception.client.*
 import com.expediagroup.openworld.sdk.core.model.exception.service.*
-
+{{/isRapid}}
 
 import jakarta.validation.ConstraintViolation
 import jakarta.validation.Validation

--- a/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.expediagroup.openworld.sdk</groupId>
             <artifactId>openworld-java-sdk-core</artifactId>
-            <version>0.8.0</version>
+            <version>0.8.2</version>
         </dependency>
 
         <dependency>

--- a/openapi/src/main/resources/templates/openworld-sdk/propertyConstraintViolationException.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/propertyConstraintViolationException.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.models.exception
 
-import com.expediagroup.sdk.core.model.exception.client.OpenWorldClientException
+import com.expediagroup.openworld.sdk.core.model.exception.client.OpenWorldClientException
 
 /**
  * An exception to be thrown when a constraint on some property has been violated.

--- a/openapi/src/main/resources/templates/openworld-sdk/propertyConstraintViolationException.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/propertyConstraintViolationException.mustache
@@ -1,6 +1,11 @@
 package {{packageName}}.models.exception
 
-import com.expediagroup.openworld.sdk.core.model.exception.client.OpenWorldClientException
+{{#isRapid}}
+    import com.expediagroup.sdk.core.model.exception.client.OpenWorldClientException
+{{/isRapid}}
+{{^isRapid}}
+    import com.expediagroup.openworld.sdk.core.model.exception.client.OpenWorldClientException
+{{/isRapid}}
 
 /**
  * An exception to be thrown when a constraint on some property has been violated.


### PR DESCRIPTION
### :pencil: Description
Use the new package names.
**BREAKING CHANGE**: All imports statements need to be updated

Note: The tests won't pass because we won't publish `SDK-Core 0.8.2` to maven central.

### :link: Related Issues
https://github.com/ExpediaGroup/openworld-sdk-java-core/pull/111


---

* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.