### PR TITLE
feat(configurations): Support Configuring Request Timeout

### DIFF
--- a/openapi/src/main/resources/templates/openworld-sdk/openworld/client.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/openworld/client.mustache
@@ -39,7 +39,7 @@ import java.util.UUID
 
     class Builder : OpenWorldClient.Builder<Builder>() {
         override fun build(): {{classname}} = {{classname}}(
-            OpenWorldClientConfiguration(key, secret, endpoint, authEndpoint)
+            OpenWorldClientConfiguration(key, secret, endpoint, requestTimeout, authEndpoint)
         )
     }
 

--- a/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/pom.mustache
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.expediagroup.openworld.sdk</groupId>
             <artifactId>openworld-java-sdk-core</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.0</version>
         </dependency>
 
         <dependency>

--- a/openapi/src/main/resources/templates/openworld-sdk/rapid/client.mustache
+++ b/openapi/src/main/resources/templates/openworld-sdk/rapid/client.mustache
@@ -40,7 +40,7 @@ import java.util.UUID
 
     class Builder : BaseRapidClient.Builder<Builder>() {
         override fun build(): {{classname}} = {{classname}}(
-            RapidClientConfiguration(key, secret, endpoint)
+            RapidClientConfiguration(key, secret, endpoint, requestTimeout)
         )
     }
 


### PR DESCRIPTION
* [x] Code is up-to-date with the `main` branch.
* [x] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.